### PR TITLE
Use navlinks within header

### DIFF
--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -20,6 +20,7 @@ html, body {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    color: black;
     font-size: 1.4em;
     background-color: #F7E305;
 }
@@ -39,6 +40,7 @@ html, body {
     margin-left: 0.5em;
     text-decoration: none;
     font-weight: bold;
+    color: black;
     font-family: var(--main-text-font);
 }
 

--- a/frontend/src/header.js
+++ b/frontend/src/header.js
@@ -1,18 +1,17 @@
 import React from 'react';
+import { NavLink } from 'react-router-dom';
 import PlayDropdownMenu from './play-dropdown-menu';
 
 let Header = () =>
     <div className="header">
-        <a href="/#/" 
-            className="nav-item">
+        <NavLink to='/' className="nav-item">
             <p className="nav-item">Hidden Joys <i className="far fa-smile"></i> 
             </p>
-        </a>
+        </NavLink>
         <div className='header-right'>
-            <a href="/#/about"
-                className="nav-item">
+            <NavLink to='/about' className="nav-item">
                 <p className="nav-item">About</p>
-            </a>
+            </NavLink>
             <PlayDropdownMenu />
         </div>
     </div>

--- a/frontend/src/play-dropdown-menu.js
+++ b/frontend/src/play-dropdown-menu.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { NavLink } from 'react-router-dom';
 
 class PlayDropdownMenu extends React.Component {
     constructor(props) {
@@ -34,13 +35,13 @@ class PlayDropdownMenu extends React.Component {
                     ? (
                         <ul className="play-dropdown-menu-list">
                             <li className="dropdown-list-item">
-                                <a href="/#/search" className="dropdown-link">Search Joys</a>
+                                <NavLink to="/search" className="dropdown-link">Search Joys</NavLink>
                              </li>
                             <li className="dropdown-list-item">
-                                <a href="/#/add" className="dropdown-link">Add Joy</a>
+                                <NavLink to="/add" className="dropdown-link">Add Joy</NavLink>
                             </li>
                             <li className="dropdown-list-item">
-                                <a href="/#/found" className="dropdown-link">Found Joys</a>
+                                <NavLink to="/found" className="dropdown-link">Found Joys</NavLink>
                             </li>
                         </ul>
                     )


### PR DESCRIPTION
In this branch:

- Switched from anchor tags to NavLinks (imported from 'react-router-dom'). 

Note: This will produce a console warning error message: `Warning: Hash history cannot PUSH the same path; a new entry will not be added to the history stack` when on the same page as the link you are clicking to navigate to (Example: clicking to go to the homepage when currently on the homepage). 

Since the warning messages are not causing any navigational problems, we will keep the NavLinks as the anchor tags do not seem to work on the deployed website. 

@clinturbin: Could you please take a look and help review? 🙂