### PR TITLE
Fixed info window map re-centering issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@
             location:{lat,lng}
         })
     ```
+    - Getting one info window to display at a time when a marker was clicked turned out to be a bit more diffcult than expected. To handle this we had to make each Marker a class component so we could keep track of state. In the state we could keep track of whether or not the marker was the active marker and also if it was open. Since we stored this in state we were able to add a onClick handler to each marker to change these state values when a marker was clicked. Then, if a marker was open and was the active marker we would then render the info window to the map.

--- a/frontend/src/map-screen/item-marker.js
+++ b/frontend/src/map-screen/item-marker.js
@@ -1,23 +1,45 @@
 import React from 'react';
 import { Marker, InfoWindow } from 'react-google-maps';
-import ItemInfoWindowContent from './item-info-window'; 
+import ItemInfoWindowContent from './item-info-window';
 
-let ItemMarker = (props) => 
-    <Marker
-        onClick={() => {
-            props.updateActiveMarker(props.item);
-        }}
-        position={props.location}
-    >
-    {props.item === props.activeMarker
-        ? <InfoWindow
-            maxWidth={300}
-            position={props.location}
-            onCloseClick={() => props.updateActiveMarker(null)} 
-        >
-            <ItemInfoWindowContent item={props.item}/>
-        </InfoWindow>
-        : null}
-    </Marker>
+class ItemMarker extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            isOpen: false,
+            activeMarker: this.props.activeMarker
+        }
+    }
+    toggleOpen = () => {
+        this.setState({isOpen: !this.state.isOpen}, () => {
+            if (!this.state.isOpen) {
+                this.setState({activeMarker: false}, () => {
+                    this.props.closeMarkers(null)
+                })
+            } else {
+                this.props.closeMarkers(this.props.itemId)
+            }
+        })
+    };
+    componentWillReceiveProps(nextProps) {
+        this.setState({activeMarker: nextProps.activeMarker})
+    };
+    render() {
+        return (
+            <div>
+                <Marker
+                    onClick={this.toggleOpen}
+                    position={this.props.location}
+                >
+                { this.state.isOpen && this.state.activeMarker ?
+                    <InfoWindow maxWidth={400} defaultPosition={ this.props.location } onCloseClick={this.props.onToggleOpen}>
+                        <ItemInfoWindowContent item={this.props.item}/>
+                    </InfoWindow> : null
+                }
+                </Marker>
+            </div>
+        )
+    }
+};
 
 export default ItemMarker;

--- a/frontend/src/map-screen/search-map-container.js
+++ b/frontend/src/map-screen/search-map-container.js
@@ -2,29 +2,38 @@ import React from "react";
 import SearchMap from './search-map';
 import keys from '../keys';
 
-
 class SearchMapContainer extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
+            items: [],
+            location: this.props.location,
             activeMarker: null
         };
     };
 
-    updateActiveMarker = (item) => {
-        this.setState({activeMarker: item});
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.items !== this.props.items) {
+            this.setState({
+                items: nextProps.items,
+                location: nextProps.location
+            });
+        };
     };
+
+    closeOtherMarkers = (itemId) => this.setState({activeMarker: itemId});
 
     render() {
         return (
             <SearchMap 
+                items={this.props.items}
+                location={this.props.location}
                 googleMapURL={`https://maps.googleapis.com/maps/api/js?key=${keys.GOOGLE_MAPS_API_KEY}&v=3.exp&libraries=geometry,drawing,places`}
                 loadingElement={<div style={{ height: `100%` }} />}
                 containerElement={<div style={{ height: `100%`, width: `100%` }} />}
                 mapElement={<div style={{ height: `100%` }} />}
-                location={this.props.location}
                 activeMarker={this.state.activeMarker}
-                updateActiveMarker={this.updateActiveMarker}
+                closeOtherMarkers={this.closeOtherMarkers}
             />
         )
     }

--- a/frontend/src/map-screen/search-map.js
+++ b/frontend/src/map-screen/search-map.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { connect } from 'react-redux';
 import { withScriptjs, withGoogleMap, GoogleMap } from "react-google-maps";
 import ItemMarker from './item-marker';
 
@@ -8,26 +7,20 @@ const SearchMap = withScriptjs(withGoogleMap((props) =>  {
             <ItemMarker 
                 key={item.id}
                 itemId={item.id}
-                location={{lat:Number(item.lat), lng:Number(item.lng)}}
-                updateActiveMarker={props.updateActiveMarker}
+                closeMarkers={props.closeOtherMarkers}
                 item={item}
-                activeMarker={props.activeMarker}
+                location={{lat:Number(item.lat), lng:Number(item.lng)}}
+                activeMarker={item.id === props.activeMarker ? true : false}
             />
         )
     return (
         <GoogleMap
             defaultZoom={14}
-            center={ {lat: props.lat, lng: props.lng} }
-            onClick={() => {props.updateActiveMarker(null)}}
-            onCenterChanged={() => {
-                console.log('Center Changed')
-            }}
+            center={ props.location }
         >
         {markers}
         </GoogleMap>
     )
 }));
 
-export default connect(
-    state => ({lat: state.lat, lng: state.lng, items:state.items})
-)(SearchMap);
+export default SearchMap;

--- a/frontend/src/search-map-screen.js
+++ b/frontend/src/search-map-screen.js
@@ -12,13 +12,11 @@ class SearchMapScreen extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            lat: this.props.lat,
-            lng: this.props.lng
+            location: {lat:this.props.lat, lng: this.props.lng}
         }
     };
 
     componentDidMount() {
-        // Get All Items from Database and add them to global store
         fetch(process.env.REACT_APP_API_URL + '/items')
         .then(res => res.json())
         .then(items => {
@@ -39,8 +37,9 @@ class SearchMapScreen extends React.Component {
                         <PlacesWithStandaloneSearchBox />
                     </div>
                     <div className='map-container'>
-                        <SearchMapContainer 
-                            location={ {lat: this.state.lat, lng: this.state.lng} }
+                        <SearchMapContainer
+                            location={ {lat: this.props.lat, lng: this.props.lng } }
+                            items={this.props.items}
                         />
                     </div>
                     <div className='form-btns-container'>


### PR DESCRIPTION
For this branch:
- I fixed the issue where opening and closing an info window would cause the map to recenter to its previous location.  I used some sample code to rework things so I am not fully sure what exactly fixed the issue. I think it was either from changing the Marker to a class component or from messing around with the map center location properties.
- Also, the info window opening and closing is still a bit glitchy. If there is time I will go back and try to deal with it, but for now I think it is good enough to move on to something else.

@running-on-sunshine: Could you please review?