### PR TITLE
Linked Info Window to Item Detail Screen

### DIFF
--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -8,6 +8,9 @@ html, body {
     --dark-button-color: rgb(255, 149, 11);
     --light-button-color: papayawhip;
 }
+* {
+    box-sizing: border-box;
+}
 
 .full-screen {
     width: 100%;

--- a/frontend/src/add-item-screen.js
+++ b/frontend/src/add-item-screen.js
@@ -12,7 +12,7 @@ class AddItemScreen extends React.Component {
         this.state = {
             title: '',
             location:'current',
-            image: 'https://unsplash.com/photos/_0aKQa9gr4s',
+            image: 'https://source.unsplash.com/_0aKQa9gr4s/',
             description: ''
         }
     };

--- a/frontend/src/item-details-screen.js
+++ b/frontend/src/item-details-screen.js
@@ -2,16 +2,44 @@ import React from 'react';
 import Header from './header';
 import Footer from './footer';
 
-let ItemDetailsScreen = () =>
-    <div className="full-screen">
-        <Header />
-        <div className="screen">
-            <h3>Title</h3>
-            <p>Item Location</p>
-            <p>Image</p>
-            <p>Description/hints</p>
-        </div>
-        <Footer />
-    </div>
+class ItemDetailScreen extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            urlId: '',
+            item: ''
+        };
+    };
 
-export default ItemDetailsScreen;
+    componentDidMount() {
+        let urlId = this.props.match.params.id;
+        fetch(`${process.env.REACT_APP_API_URL}/items/${urlId}`)
+        .then(res => res.json())
+        .then(data => {
+            this.setState({item: data.data});
+            this.setState({urlId: urlId});
+        })
+    };
+
+    render() {
+        return (
+            <div>
+                <Header />
+                <div className='screen'>
+                    {this.state.item === 'Error' ? 
+                        <div>BAD URL</div> :
+                        <div>
+                            <h3>{`Title: ${this.state.item.title}`}</h3>
+                            <p>{`Location: Lat:${this.state.item.lat} / Lng: ${this.state.item.lng}`}</p>
+                            <p>{`Image url: ${this.state.item.image}`}</p>
+                            <p>{`Description: ${this.state.item.description}`}</p>
+                        </div> 
+                    }
+                </div>
+                <Footer />
+            </div>
+        )
+    }
+};
+
+export default ItemDetailScreen;

--- a/frontend/src/map-screen/item-info-window.js
+++ b/frontend/src/map-screen/item-info-window.js
@@ -1,11 +1,26 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import '../stylesheets/map-styling.css';
 
 let ItemInfoWindowContent = (props) => {
+    let styles = {
+        background: `url(https://source.unsplash.com/_0aKQa9gr4s/)`, //placeholder image
+        // background: `url(${props.item.image})`,
+        backgroundSize: 'contain'
+    };
+
     return (
-        <div>
-            <p>{props.item.title}</p>
-            <p>Image</p>
-            <p>Link</p>
+        <div className='info-window-container'>
+            <div className='info-window-section'>
+                <div className='info-window-image' style={styles}></div>
+            </div>
+            <div className='info-window-section'>
+                <p className='info-window-title'>{props.item.title}</p>
+                <p className='info-window-status'>{props.item.found ? 'Found' : 'Not Found'}</p>
+                <Link to={`/items/${props.item.id}`} >
+                    <p className='info-window-link'>Item Details</p>
+                </Link>
+            </div>
         </div>
     )
 };

--- a/frontend/src/map-screen/item-marker.js
+++ b/frontend/src/map-screen/item-marker.js
@@ -32,7 +32,7 @@ class ItemMarker extends React.Component {
                     position={this.props.location}
                 >
                 { this.state.isOpen && this.state.activeMarker ?
-                    <InfoWindow maxWidth={800} maxHeigth={800} defaultPosition={ this.props.location } onCloseClick={this.props.onToggleOpen}>
+                    <InfoWindow maxWidth={800} maxHeight={800} defaultPosition={ this.props.location } onCloseClick={this.props.onToggleOpen}>
                         <ItemInfoWindowContent item={this.props.item}/>
                     </InfoWindow> : null
                 }

--- a/frontend/src/map-screen/item-marker.js
+++ b/frontend/src/map-screen/item-marker.js
@@ -32,7 +32,7 @@ class ItemMarker extends React.Component {
                     position={this.props.location}
                 >
                 { this.state.isOpen && this.state.activeMarker ?
-                    <InfoWindow maxWidth={400} defaultPosition={ this.props.location } onCloseClick={this.props.onToggleOpen}>
+                    <InfoWindow maxWidth={800} maxHeigth={800} defaultPosition={ this.props.location } onCloseClick={this.props.onToggleOpen}>
                         <ItemInfoWindowContent item={this.props.item}/>
                     </InfoWindow> : null
                 }

--- a/frontend/src/stylesheets/map-styling.css
+++ b/frontend/src/stylesheets/map-styling.css
@@ -22,6 +22,51 @@
     padding: 2px 10px;
 }
 
+.info-window-container {
+    display: flex;
+    align-items: center;
+    margin: .5em;
+}
+.info-window-image {
+    width: 50px;
+    height: 50px;
+}
+
+.info-window-section {
+    margin: .5em;
+}
+
+.info-window-title {
+    font-family: var(--main-text-font);
+    font-weight: bold;
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.info-window-status {
+    font-family: var(--main-text-font);
+    font-size: 1rem;
+}
+
+.info-window-link {
+    font-family: var(--main-text-font);
+    font-size: 1.2rem;
+    margin: 0;
+}
+
+@media(min-width: 360px) {
+    .info-window-image {
+        width: 70px;
+        height: 70px;
+    }
+    .info-window-title, .info-window-link {
+        font-size: 1.5rem;
+    }
+    .info-window-status {
+        font-size: 1.2rem;
+    }
+}
+
 @media(min-width: 768px) {
     .search-box {
         width: 33rem;


### PR DESCRIPTION
For this branch:
- In item-info-window.js, I replaced placeholder content with selected marker content and linked info window to ItemDetailScreen
- In item-detail-screen.js, I converted to class component so I could have access to componentDidMount. This allowed me to do . fetch request to the database to get the correct item information.
- The item information is currently added to the screen, but I didn't do any styling to the ItemDetailScreen

@running-on-sunshine: Could you please review?