### PR TITLE
User can add hints

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,3 +2,5 @@
 /node_modules
 
 .env
+
+/database/seeds.sql

--- a/backend/database/schema.sql
+++ b/backend/database/schema.sql
@@ -1,10 +1,16 @@
 CREATE TABLE items (
-    id character varying(255) PRIMARY KEY,
+    id serial PRIMARY KEY,
     title character varying(255),
     lat numeric NOT NULL,
     lng numeric NOT NULL,
     image character varying(255),
-    description character varying(255),
-    found BOOLEAN DEFAULT false,
-    comment character varying(255)
+    found_code character varying(255),
+    item_found BOOLEAN DEFAULT false,
+    found_comment text
+);
+
+CREATE TABLE hints (
+    id serial PRIMARY KEY,
+    item_id INTEGER REFERENCES items(id),
+    hint character varying(255)
 );

--- a/backend/database/seeds.sql
+++ b/backend/database/seeds.sql
@@ -1,6 +1,0 @@
-INSERT INTO items (id, title, lat, lng, image, description)
-VALUES ('aj8b873m9q', 'Title 1', 33.846883, -84.361880, 'https://unsplash.com/photos/_0aKQa9gr4s', 'Lenox Square');
-INSERT INTO items (id, title, lat, lng, image, description)
-VALUES ('zry6552v8d', 'Title 2', 33.842809, -84.386199, 'https://unsplash.com/photos/_0aKQa9gr4s', 'Atlanta History Center');
-INSERT INTO items (id, title, lat, lng, image, description)
-VALUES ('paxjjry75z', 'Title 3', 33.854647, -84.383310, 'https://unsplash.com/photos/_0aKQa9gr4s', 'Punchline Comedy Club');

--- a/backend/server.js
+++ b/backend/server.js
@@ -13,7 +13,7 @@ server.use(cors());
 let addNewItemQuery = (itemObject) =>
     `INSERT INTO items (title, lat, lng, image, found_code)
      VALUES ('${itemObject.title}', ${itemObject.lat}, ${itemObject.lng}, 
-             '${itemObject.image}', '${itemObject.found_code}') RETURNING id;`;
+             '${itemObject.image}', '${itemObject.found_code}') RETURNING *;`;
 
 let addNewItem = (req, res) => {
     db.query(addNewItemQuery(req.body))

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,14 +11,14 @@ server.use(bodyParser.json());
 server.use(cors());
 
 let addNewItemQuery = (itemObject) =>
-    `INSERT INTO items (id, title, lat, lng, image, description)
-     VALUES ('${itemObject.id}', '${itemObject.title}', ${itemObject.lat}, 
-             ${itemObject.lng}, '${itemObject.image}', '${itemObject.description}');`;
+    `INSERT INTO items (title, lat, lng, image, found_code)
+     VALUES ('${itemObject.title}', ${itemObject.lat}, ${itemObject.lng}, 
+             '${itemObject.image}', '${itemObject.found_code}') RETURNING id;`;
 
 let addNewItem = (req, res) => {
-    console.log(req.body);
     db.query(addNewItemQuery(req.body))
-    .then(() => res.end());
+    .then(data => res.send(data))
+    .catch(err => res.send(err))
 };
 
 let getAllItemsQuery = () => `SELECT * FROM items;`;
@@ -60,7 +60,19 @@ let updateItemComment = (req, res) => {
     .then(() => res.end())
 };
 
+let addNewHintQuery = (itemId, hint) =>
+    `INSERT INTO hints (item_id, hint)
+    VALUES (${itemId}, '${hint}');`;
+
+let addHints = (req, res) => {
+    req.body.hints.forEach(hint => {
+        db.query(addNewHintQuery(req.body.itemId, hint.hint))
+        .then(() => res.end())
+    })
+};
+
 server.post('/items', addNewItem);
+server.post('/hints', addHints);
 server.get('/items', getAllItems);
 server.get('/items/:id', getOneItem);
 server.put('/items/:id', updateItemFoundStatus);

--- a/frontend/src/add-item-screen.js
+++ b/frontend/src/add-item-screen.js
@@ -4,16 +4,20 @@ import Header from './header';
 import Footer from './footer';
 import SearchBox from './map-screen/search-box';
 import addItemFetch from './add-item-screen/add-item-fetch';
+import NewHintForm from './add-item-screen/new-hint';
+import HintListings from './add-item-screen/hint-listing';
 import './stylesheets/add-item-screen.css';
 
 class AddItemScreen extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
+            currentHint: '',
             title: '',
             location:'current',
             image: 'https://source.unsplash.com/_0aKQa9gr4s/',
-            description: ''
+            hints: [],
+            showNoHintsMessage: false
         }
     };
 
@@ -22,15 +26,51 @@ class AddItemScreen extends React.Component {
             type: 'UPDATE_ITEM_ID',
             itemId: ''
         });
+        this.props.dispatch({
+            type: 'UPDATE_FOUND_CODE',
+            foundCode: ''
+        });
     };
 
     render() {
-        let updateItemId = (id) => {
+        let updateStoreItemId = (id) => {
             this.props.dispatch({
                 type: 'UPDATE_ITEM_ID',
                 itemId: id
             });
+        };
+
+        let updateStoreFoundCode = (code) => {
+            this.props.dispatch({
+                type: 'UPDATE_FOUND_CODE',
+                foundCode: code
+            });
+        };
+
+        let updateStoreIdAndFoundCode = (itemId, code) => {
+            updateStoreItemId(itemId);
+            updateStoreFoundCode(code);
             this.props.history.push(`/submit-success`);
+        };
+
+        let addNewHint = (hint) => {
+            let newHints = [...this.state.hints, hint]
+            this.setState({hints: newHints}) 
+        };
+
+        let removeHint = (oldHint) => {
+            let newHints = this.state.hints.filter(hint => hint.id !== oldHint.id);
+            this.setState({hints: newHints});
+        };
+
+        let hideNoHintsMessage = () => this.setState({showNoHintsMessage: false});
+
+        let submitForm = () => {
+            if (this.state.hints.length === 0 ) {
+                this.setState({showNoHintsMessage: true});
+            } else {
+                addItemFetch(this.state, this.props, updateStoreIdAndFoundCode);
+            }
         };
 
         return (
@@ -41,7 +81,7 @@ class AddItemScreen extends React.Component {
                     className='add-item-form'
                     onSubmit={event => {
                         event.preventDefault();
-                        addItemFetch(this.state, this.props, updateItemId);
+                        submitForm();
                     }}>
                         <p className='form-title'>Hide New Item</p>
                         <div className='form-section'>
@@ -70,18 +110,24 @@ class AddItemScreen extends React.Component {
                             {this.state.location === 'current' ? <p></p> : <SearchBox />}
                         </div>
                         <div className='form-section'>
-                        <p className='form-section-title'>Image</p>
-                            <input className='input-box' type="file" />
-                        </div>
-                        <div className='form-section'>
-                            <p className='form-section-title'>Description</p>
-                            <textarea 
-                                className='input-box description-box'
-                                value={this.state.description}
+                            <p className='form-section-title'>Image/url</p>
+                            <input 
+                                className='input-box'
+                                type='text'
+                                required
+                                value={this.state.image}
                                 onChange={event => {
-                                    this.setState({description: event.target.value})
+                                    this.setState({image: event.target.value})
                                 }}
                             />
+                        </div>
+                        <div className='form-section'>
+                            <p className='form-section-title'>Hints</p>
+                            <NewHintForm addNewHint={addNewHint} hideNoHintsMessage={hideNoHintsMessage}/>
+                            {this.state.showNoHintsMessage 
+                                ? <p className='no-hints-message'>Please Provide a Hint!!!</p>
+                                : <HintListings hints={this.state.hints} removeHint={removeHint}/>
+                            }
                         </div>
                         <div className='form-section'>
                             <button type='submit' className='form-button'>Submit</button>

--- a/frontend/src/add-item-screen/add-item-fetch.js
+++ b/frontend/src/add-item-screen/add-item-fetch.js
@@ -1,41 +1,94 @@
 import generateId from './generate-id';
 
-let buildBody = (state, lat, lng) => ({
-    id: generateId(),
+
+
+let newItemBody = (state, lat, lng) => ({
     title: state.title,
     lat: lat,
     lng: lng,
     image: state.image,
-    description: state.description
+    found_code: generateId(),
+    // hints: state.hints
 });
 
-let fetchRequest = (body, updateItemId) => {
-    fetch(process.env.REACT_APP_API_URL + '/items', {
+let fetchRequest = (body, hints, updateStoreIdAndFoundCode) => {
+    fetch(`${process.env.REACT_APP_API_URL}/items`, {
         method: 'POST',
         body: JSON.stringify(body),
         headers: {
             'Content-Type': 'application/json',
             'Accept': 'application/json'
         }
-    })
-    .then(() => {
-        console.log('Check database to confirm entry');
-        updateItemId(body.id);
+    }).then(res => res.json())
+    .then(data => {
+        let itemId = data[0].id;  // need to get back the newly created item so we can get its id
+        let body = {itemId, hints};
+        console.log(body);
+        fetch(`${process.env.REACT_APP_API_URL}/hints`, {
+            method: 'POST',
+            body: JSON.stringify(body),
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            }
+        }).then(() => {
+            console.log('check Database')
+        })
+        
+        // need to insert the hints into database
+        // /items/:id/hints
+        // console.log(data[0].id); // this is the id after entering into database
+        // updateStoreIdAndFoundCode(body.id); // this should get the found_code and store it in global store
+        // updateStoreIdAndFoundCode(id, code);
     })
 };
 
-let addItemFetch = (state, props, updateItemId) => {
+let addItemFetch = (state, props, updateStoreIdAndFoundCode) => {
     if (state.location === 'current') {
         navigator.geolocation.getCurrentPosition(position => {
             let lat = position.coords.latitude;
             let lng = position.coords.longitude;
-            let body = buildBody(state, lat, lng);
-            fetchRequest(body, updateItemId);
+            let body = newItemBody(state, lat, lng);
+            fetchRequest(body, state.hints, updateStoreIdAndFoundCode);
         });
     } else {
-        let body = buildBody(state, props.lat, props.lng);
-        fetchRequest(body, updateItemId);
+        let body = newItemBody(state, props.lat, props.lng);
+        fetchRequest(body, state.hints, updateStoreIdAndFoundCode);
     }
 };
 
 export default addItemFetch;
+
+// INSERT INTO items (title, lat, lng, image, found_code)
+// VALUES ('Buckhead Station', 33.849623, -84.370207, 'https://source.unsplash.com/fH_Oag_bA1c/', 'zpq8965k3j');
+
+// let fetchRequest = (body, updateItemId) => {
+//     fetch(process.env.REACT_APP_API_URL + '/items', {
+//         method: 'POST',
+//         body: JSON.stringify(body),
+//         headers: {
+//             'Content-Type': 'application/json',
+//             'Accept': 'application/json'
+//         }
+//     })
+//     .then(() => {
+//         console.log('Check database to confirm entry');
+//         updateItemId(body.id);
+//     })
+// };
+
+// let addItemFetch = (state, props, updateItemId) => {
+//     if (state.location === 'current') {
+//         navigator.geolocation.getCurrentPosition(position => {
+//             let lat = position.coords.latitude;
+//             let lng = position.coords.longitude;
+//             let body = buildBody(state, lat, lng);
+//             fetchRequest(body, updateItemId);
+//         });
+//     } else {
+//         let body = buildBody(state, props.lat, props.lng);
+//         fetchRequest(body, updateItemId);
+//     }
+// };
+
+// export default addItemFetch;

--- a/frontend/src/add-item-screen/add-item-fetch.js
+++ b/frontend/src/add-item-screen/add-item-fetch.js
@@ -1,14 +1,11 @@
 import generateId from './generate-id';
 
-
-
 let newItemBody = (state, lat, lng) => ({
     title: state.title,
     lat: lat,
     lng: lng,
     image: state.image,
     found_code: generateId(),
-    // hints: state.hints
 });
 
 let fetchRequest = (body, hints, updateStoreIdAndFoundCode) => {
@@ -21,9 +18,9 @@ let fetchRequest = (body, hints, updateStoreIdAndFoundCode) => {
         }
     }).then(res => res.json())
     .then(data => {
-        let itemId = data[0].id;  // need to get back the newly created item so we can get its id
+        let itemId = data[0].id;
+        let foundCode = data[0].found_code;
         let body = {itemId, hints};
-        console.log(body);
         fetch(`${process.env.REACT_APP_API_URL}/hints`, {
             method: 'POST',
             body: JSON.stringify(body),
@@ -32,14 +29,8 @@ let fetchRequest = (body, hints, updateStoreIdAndFoundCode) => {
                 'Accept': 'application/json'
             }
         }).then(() => {
-            console.log('check Database')
+            updateStoreIdAndFoundCode(itemId, foundCode);
         })
-        
-        // need to insert the hints into database
-        // /items/:id/hints
-        // console.log(data[0].id); // this is the id after entering into database
-        // updateStoreIdAndFoundCode(body.id); // this should get the found_code and store it in global store
-        // updateStoreIdAndFoundCode(id, code);
     })
 };
 
@@ -58,37 +49,3 @@ let addItemFetch = (state, props, updateStoreIdAndFoundCode) => {
 };
 
 export default addItemFetch;
-
-// INSERT INTO items (title, lat, lng, image, found_code)
-// VALUES ('Buckhead Station', 33.849623, -84.370207, 'https://source.unsplash.com/fH_Oag_bA1c/', 'zpq8965k3j');
-
-// let fetchRequest = (body, updateItemId) => {
-//     fetch(process.env.REACT_APP_API_URL + '/items', {
-//         method: 'POST',
-//         body: JSON.stringify(body),
-//         headers: {
-//             'Content-Type': 'application/json',
-//             'Accept': 'application/json'
-//         }
-//     })
-//     .then(() => {
-//         console.log('Check database to confirm entry');
-//         updateItemId(body.id);
-//     })
-// };
-
-// let addItemFetch = (state, props, updateItemId) => {
-//     if (state.location === 'current') {
-//         navigator.geolocation.getCurrentPosition(position => {
-//             let lat = position.coords.latitude;
-//             let lng = position.coords.longitude;
-//             let body = buildBody(state, lat, lng);
-//             fetchRequest(body, updateItemId);
-//         });
-//     } else {
-//         let body = buildBody(state, props.lat, props.lng);
-//         fetchRequest(body, updateItemId);
-//     }
-// };
-
-// export default addItemFetch;

--- a/frontend/src/add-item-screen/hint-listing.js
+++ b/frontend/src/add-item-screen/hint-listing.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+let HintListings = (props) => 
+    <div className='hint-listings'>
+        {props.hints.map(hint => 
+            <div className='hint-listing' key={hint.id}>
+                <p className='hint-listing-text'>{hint.hint}</p>
+                <button
+                    className='form-button'
+                    onClick={() => {
+                        props.removeHint(hint)
+                    }}
+                >-</button>
+            </div>
+        ).reverse()}
+    </div>
+
+export default HintListings;

--- a/frontend/src/add-item-screen/new-hint.js
+++ b/frontend/src/add-item-screen/new-hint.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+class NewHintForm extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            hint: ''
+        };
+    };
+    render() {
+        let generateId = () => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString();
+        return (
+            <div className='new-hint-container'>
+                <input
+                    className='input-box fill-height'
+                    type='text'
+                    value={this.state.hint}
+                    onChange={event => {
+                        this.setState({hint: event.target.value})
+                    }}
+                />
+                <button
+                    className='form-button fill-height'
+                    onClick={event => {
+                        event.preventDefault();
+                        this.props.hideNoHintsMessage();
+                        this.props.addNewHint({id: generateId(), hint: this.state.hint});
+                        this.setState({hint: ''});
+                    }}
+                >+</button>
+            </div>
+        )
+    }
+};
+
+export default NewHintForm;

--- a/frontend/src/reducer.js
+++ b/frontend/src/reducer.js
@@ -6,12 +6,15 @@ let updateLocation = (oldState, action) => {
 
 let updateItemId = (oldState, action) => ({...oldState, itemId: action.itemId});
 
+let updateFoundCode = (oldState, action) => ({...oldState, foundCode: action.foundCode});
+
 let updateItems = (oldState, action) => ({...oldState, items: action.items});
 
 let reducers = {
     'UPDATE_LOCATION': updateLocation,
     'UPDATE_ITEM_ID': updateItemId,
-    'UPDATE_ITEMS': updateItems
+    'UPDATE_ITEMS': updateItems,
+    'UPDATE_FOUND_CODE': updateFoundCode
 };
 
 let reducer = (oldState, action) => {

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -6,7 +6,8 @@ let initialState = {
     lng: -84.3880,
     items:[],
     currentLocation: {lat:'',lng:''},
-    itemId: ''
+    itemId: '',
+    foundCode: ''
 };
 
 let store = createStore(

--- a/frontend/src/stylesheets/add-item-screen.css
+++ b/frontend/src/stylesheets/add-item-screen.css
@@ -88,7 +88,6 @@
 .input-box {
     background-color: white;
     box-sizing: border-box;
-    border: 1 px solid transparent;
     width: 200px;
     border: 1px solid transparent;
     border-radius: 3px;
@@ -114,6 +113,43 @@
 
 .form-btns-container {
     display: flex;
+}
+
+.new-hint-container {
+    display: flex;
+    align-items: center;
+    height: 2.5em;
+}
+
+.fill-height {
+    height: 100%;
+}
+
+.hint-listings {
+    width: 80%;
+    margin: 1.5em;
+    border: 1px solid black;
+    border-radius: .5em;
+}
+
+.hint-listing {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid black;
+}
+
+.hint-listing-text {
+    padding-left: 1em;
+    font-size: 1.2rem;
+}
+
+.no-hints-message {
+    font-family: var(--main-text-font);
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin: 0;
+    padding-top: 1em;
 }
 
 @media(min-width: 768px) {

--- a/frontend/src/submission-successful-screen.js
+++ b/frontend/src/submission-successful-screen.js
@@ -43,5 +43,5 @@ class SubmissionSuccessfulScreen extends React.Component {
 };  
 
 export default connect(
-    state => ({itemId: state.itemId})
+    state => ({itemId: state.itemId, foundCode: state.foundCode})
 )(SubmissionSuccessfulScreen);

--- a/frontend/src/submission-successful-screen.js
+++ b/frontend/src/submission-successful-screen.js
@@ -21,7 +21,7 @@ class SubmissionSuccessfulScreen extends React.Component {
                             <p className='form-text'>Thank you very much for adding some joy into the world!</p>
                             <p className='form-text'>Your item id is:</p>
                             <div className='input-box id-box'>
-                                <p className='id-text'>{this.props.itemId}</p>
+                                <p className='id-text'>{this.props.foundCode}</p>
                             </div>
                         </div>
                         <div className='form-section'>


### PR DESCRIPTION
On this branch:
- On the AddItemScreen, the user can now add new hints to their item instead of just one description
- I added some validation that prevents a user from submitting a new item form without including at least 1 hint. If they try to submit a form with no hints, they are shown a little message asking them to include some hints.
- I created a new database schema so you will need to update your local database for this to work. I will send you some seeds data also so you can update your database with some information.
- This branch only deals with the new item screen. My next task will be to update the found items logic

@running-on-sunshine: Could you please review?