### PR TITLE
Added content and styling to Item Details Page

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -96,12 +96,22 @@ let getFoundItems = (req, res) => {
     .catch(err => res.send({error: err}))
 };
 
+let getItemHintsQuery = (itemId) => 
+    `SELECT * FROM hints WHERE item_id = ${itemId};`;
+
+let getItemHints = (req, res) => {
+    db.query(getItemHintsQuery(req.params.id))
+    .then(data => res.send({data}))
+    .catch(err => res.send({data: 'Error', error: err}))
+};
+
 server.post('/items', addNewItem);
 server.post('/hints', addHints);
 server.get('/items', getAllItems);
 server.get('/items/hidden', getHiddenItems);
 server.get('/items/found', getFoundItems);
 server.get('/items/:id', getOneItem);
+server.get('/items/:id/hints', getItemHints);
 server.get('/codes/:id', getItemByCode);
 server.put('/items/:id/found', updateItemFoundStatus);
 server.put('/items/:id/comment', updateItemComment);

--- a/frontend/src/item-details-screen.js
+++ b/frontend/src/item-details-screen.js
@@ -2,6 +2,8 @@ import React from 'react';
 import Header from './header';
 import Footer from './footer';
 import ImageLinkErrorMessage from './item-details-screen/image-link-error-message';
+import ItemDetailScreenMapContainer from './item-details-screen/item-detail-map';
+import ItemDetailsForm from './item-details-screen/item-details-form';
 import './stylesheets/item-details-screen.css';
 
 class ItemDetailsScreen extends React.Component {
@@ -9,7 +11,8 @@ class ItemDetailsScreen extends React.Component {
         super(props);
         this.state = {
             urlId: '',
-            item: ''
+            item: '',
+            hints: []
         };
     };
 
@@ -20,6 +23,9 @@ class ItemDetailsScreen extends React.Component {
         .then(data => {
             this.setState({item: data.data});
             this.setState({urlId: urlId});
+            fetch(`${process.env.REACT_APP_API_URL}/items/${urlId}/hints`)
+            .then(res => res.json())
+            .then(data => this.setState({hints: data.data}))
         })
     };
 
@@ -27,25 +33,14 @@ class ItemDetailsScreen extends React.Component {
         return (
             <div className='full-screen'>
                 <Header />
-                <div className='screen success-image-background'>
+                <div className='screen success-image-background center-div'>
                     {this.state.item === 'Error' ? 
                         <ImageLinkErrorMessage />:
-                        <div className='form-container'>
-                            <div className='add-item-form'>
-                                <h3 className='form-title'>{`${this.state.item.title}`}</h3>
-                                <p className='form-text'>{`Location: Lat:${this.state.item.lat} / Lng: ${this.state.item.lng}`}</p>
-                                <div className='form-section map-detail-container'>
-                                    <div>Map goes here</div>
-                                </div>
-                                <div className='form-section image-container'>
-                                    <p className='form-text'>Image</p>
-                                    <p className='item-image'>{`${this.state.item.image}`}</p>
-                                </div>
-                                <div className='form-section hints-container'>
-                                    <p className='form-text'>Hints</p>
-                                    <p className='form-text'>{`${this.state.item.description}`}</p>
-                                </div>
-                            </div> 
+                        <div className='item-details-container'>
+                            <div className='desktop-map-display'>
+                                <ItemDetailScreenMapContainer lat={this.state.item.lat} lng={this.state.item.lng}/>
+                            </div>
+                            <ItemDetailsForm item={this.state.item} hints={this.state.hints}/>
                         </div>
                     }
                 </div>

--- a/frontend/src/item-details-screen/item-detail-map.js
+++ b/frontend/src/item-details-screen/item-detail-map.js
@@ -1,0 +1,8 @@
+import React from 'react';
+
+let ItemDetailScreenMapContainer = (props) => 
+    <div className='item-detail-map-container'>
+        <iframe src={`https://www.google.com/maps/embed?pb=!1m21!1m12!1m3!1d3356.8829468635663!2d${props.lng}!3d${props.lat}!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m6!3e6!4m0!4m3!3m2!1d${props.lat}!2d${props.lng}!5e0!3m2!1sen!2sus!4v1539189750210`} width="100%" height="100%" frameBorder="0" style={{border:"0"}} allowFullScreen></iframe>
+    </div>
+
+export default ItemDetailScreenMapContainer;

--- a/frontend/src/item-details-screen/item-details-form.js
+++ b/frontend/src/item-details-screen/item-details-form.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import ItemDetailsStatusContainer from './item-details-status-container';
+import ItemDetailScreenMapContainer from './item-detail-map';
+import ItemDetailsHints from './item-details-hints';
+
+let ItemDetailsForm = (props) => 
+    <div className='item-detail-form'>
+        <div className='item-detail-form-header center-div'>
+            <h3 className='item-detail-title'>{`${props.item.title}`}</h3>
+        </div>
+        <hr/>
+        <div className='item-detail-form-body'>
+            <ItemDetailsStatusContainer item={props.item}/>
+            <div className='item-detail-body-section'>
+                <div className='mobile-map-display'>
+                    <ItemDetailScreenMapContainer lat={props.item.lat} lng={props.item.lng}/>
+                </div>
+            </div>
+            <ItemDetailsHints hints={props.hints}/>
+        </div>
+        <hr/>
+        <div className='item-detail-form-footer center-div'>
+            <Link to='/add'><button className='detail-screen-button'>Add</button></Link>
+            <Link to='/search'><button className='detail-screen-button'>Search</button></Link>
+        </div>
+    </div>
+
+export default ItemDetailsForm;

--- a/frontend/src/item-details-screen/item-details-hints.js
+++ b/frontend/src/item-details-screen/item-details-hints.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+let ItemDetailsHints = (props) => 
+    <div className='item-detail-body-section'>
+        <p className='item-details-section-title'>Hints</p>
+        <div className='hints-container'>
+            {props.hints.map(hint =>
+                <p className='item-detail-hint-listing' key={hint.id}>{hint.hint}</p>    
+            )}
+        </div>
+    </div>
+
+export default ItemDetailsHints;

--- a/frontend/src/item-details-screen/item-details-status-container.js
+++ b/frontend/src/item-details-screen/item-details-status-container.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+let ItemDetailsStatusContainer = (props) =>
+    <div className='item-detail-body-section status-wrapper'>
+        <div 
+            className='item-detail-image-container'
+            style={{
+                backgroundImage:`url(${props.item.image}`,
+                backgroundSize:'cover'
+            }}
+        ></div>
+        <div className='item-detail-status-section'>
+            <p className='item-details-section-title'>Status:</p>
+            {props.item.item_found ?
+            <div className='status-display-container'>
+                <p className='item-details-status-text'>Item Found!!</p>
+                <div className='status-comment-container'>
+                    <p className='status-comment-font'>{props.item.found_comment}</p>
+                </div>
+            </div> :
+            <div className='status-display-container'>
+                <p className='item-details-status-text'>Item Still Hidden!!</p>
+                <div className='status-comment-container'>
+                    <Link to='/found'><button className='detail-screen-button'>Found</button></Link>
+                </div>
+            </div>
+            }
+        </div>
+    </div>
+
+export default ItemDetailsStatusContainer;

--- a/frontend/src/stylesheets/item-details-screen.css
+++ b/frontend/src/stylesheets/item-details-screen.css
@@ -1,3 +1,181 @@
 .map-detail-container, .image-container, .hints-container {
     border: 1px solid black;
 }
+
+.center-div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+hr {
+    margin: 0 auto;
+    width: 80%;
+    border: .5px solid var(--dark-button-color);
+}
+
+.item-details-container {
+    height: 90%;
+    width: 30em;
+    border: 2px solid var(--dark-button-color);
+    background-color: var(--light-button-color);
+    border-radius: 1em;
+}
+
+.item-detail-form {
+    height: 100%;
+    width: 100%;
+}
+
+.item-detail-form-header {
+    height: 15%;
+}
+
+.item-detail-title {
+    margin: 0;
+    font-family: var(--title-font);
+    font-size: 2rem;
+}
+.item-detail-form-body {
+    height: 70%;
+    overflow-y: scroll;
+}
+
+.item-detail-body-section {
+    width: 90%;
+    margin: 1em auto;
+}
+
+.item-detail-map-container {
+    width: 20em;
+    height: 20em;
+    margin: auto;
+    border: 2px solid var(--dark-button-color);
+}
+
+.item-detail-image-container {
+    width: 45%;
+    padding-top: 45%;
+    border: 2px solid var(--dark-button-color);
+}
+
+.item-details-section-title {
+    margin: 0;
+    font-family: var(--title-font);
+    font-size: 2rem;
+    text-align: center
+}
+
+.status-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.item-detail-status-section {
+    width: 55%;
+}
+
+.item-details-status-text {
+    font-family: var(--main-text-font);
+    font-size: 1.5rem;
+    margin: 0;
+    padding: .5em;
+    text-align: center;
+}
+
+.status-comment-container {
+    display: flex;
+    justify-content: center;
+    padding: 1em .5em;
+}
+
+.status-comment-font {
+    font-family: var(--main-text-font);
+    font-size: 1.2rem;
+    margin: 0;
+    text-align: center;
+}
+
+.hints-container {
+    width: 85%;
+    margin: .5em auto;
+    border: 1px solid black;
+    border-radius: .5em;
+}
+
+.item-detail-hint-listing {
+    margin: 0;
+    font-family: var(--main-text-font);
+    font-size: 1.2rem;
+    padding: .5em;
+    text-align: center;
+    border-bottom: 1px solid black;
+}
+
+.item-detail-form-footer {
+    height: 15%;
+}
+
+.detail-screen-button {
+    background-color: var(--dark-button-color);
+    font-size: 1.2rem;
+    width: 7em;
+    height: 3em;
+    margin: 0 1em;
+    padding: .5em 1em;
+    border-radius: .3em;
+    border: none;
+    color: white;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+.desktop-map-display {
+    display: none;
+}
+
+@media(min-width: 768px) {
+    .mobile-map-display {
+        display: none;
+    }
+    .item-details-container {
+        width: 90%;
+        display: flex;
+    }
+    .item-detail-form {
+        width: 45%;
+    }
+    .desktop-map-display {
+        width: 55%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+    .item-detail-map-container {
+        width: 90%;
+        height: 80%;
+    }
+    .detail-screen-button {
+        font-size: 1.5rem;
+
+    }
+}
+
+@media(min-width: 1200px) {
+    .item-details-container {
+        width: 70%;
+    }
+}
+
+@media(min-height: 768px) {
+    .item-details-container {
+        height: 500px;
+    }
+}
+
+@media(min-height: 1200px) {
+    .item-details-container {
+        height: 700px;
+    }
+}
+


### PR DESCRIPTION
For this branch:
- I added an additional fetch request to the ComponentDidMount function to also get a list of hints for an item and store it in the local state
- I separated the ItemDetailsScreen into smaller components and saved them in the item-details-screen folder
- I applied styling for mobile and desktop layouts. Given the custom nature of the layout for this screen I didn't use the class names we have been previously using.

@running-on-sunshine: Could you please review?